### PR TITLE
Bump protobuf-generic version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val hadoopVersion = "2.7.4"
 val avroVersion = "1.8.2"
 val parquetVersion = "1.9.0"
 val protobufVersion = "3.4.0"
-val protobufGenericVersion = "0.2.2"
+val protobufGenericVersion = "0.2.3"
 
 val commonSettings = Project.defaultSettings ++ assemblySettings ++ Seq(
   scalaVersion := "2.11.12",


### PR DESCRIPTION
Protobuf generic new version `0.2.3` support protobuf options and custom options.

Options in [Proto2](https://developers.google.com/protocol-buffers/docs/proto#options) and [Proto3](https://developers.google.com/protocol-buffers/docs/proto3#options)
Custom options in [Proto2](https://developers.google.com/protocol-buffers/docs/proto#customoptions) and [Proto3](https://developers.google.com/protocol-buffers/docs/proto3#custom_options)