### PR TITLE
Configure Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.gitignore
+.travis.yml
+LICENSE
+make-binary.sh
+NOTICE
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM mozilla/sbt AS builder
+
+WORKDIR /src
+
+COPY . .
+
+RUN sbt clean assembly
+
+RUN mkdir /out \
+  && cp avro-tools/target/scala-*/avro-tools-*.jar /out/avro-tools.jar \
+  && cp parquet-tools/target/scala-*/parquet-tools-*.jar /out/parquet-tools.jar \
+  && cp proto-tools/target/scala-*/proto-tools-*.jar /out/proto-tools.jar
+
+FROM openjdk:8-jre-slim
+
+COPY --from=builder /out/avro-tools.jar /bin/avro-tools.jar
+COPY --from=builder /out/parquet-tools.jar /bin/parquet-tools.jar
+COPY --from=builder /out/proto-tools.jar /bin/proto-tools.jar
+
+RUN echo "#!/bin/bash" > /usr/local/bin/avro \
+  && echo "java -jar /bin/avro-tools.jar \$@" >> /usr/local/bin/avro \
+  && chmod +x /usr/local/bin/avro \
+  && echo "#!/bin/bash" > /usr/local/bin/parquet \
+  && echo "java -jar /bin/parquet-tools.jar \$@" >> /usr/local/bin/parquet \
+  && chmod +x /usr/local/bin/parquet \
+  && echo "#!/bin/bash" > /usr/local/bin/proto \
+  && echo "java -jar /bin/proto-tools.jar \$@" >> /usr/local/bin/proto \
+  && chmod +x /usr/local/bin/proto

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0-RC3
+sbt.version=1.3.0


### PR DESCRIPTION
The idea is that a user who has Docker installed, needs not install the build tooling
for this project, but can instead build a docker image that contains all the necessary
executables.

For example, you can now do
```sh
$ docker build -t spotify/gcs-tools .
$ docker run --rm spotify/gcs-tools avro --help
Version 1.8.2
 of GCS compatible Apache Avro Tools
----------------
Available tools:
          cat  extracts samples from files
      compile  Generates Java code for the given schema.
       concat  Concatenates avro files without re-compressing.
   fragtojson  Renders a binary-encoded Avro datum as JSON.
     fromjson  Reads JSON records and writes an Avro data file.      
...etc
```
Although nothing has been done towards that goal here, this Docker image could be
published to Docker Hub from CI, and users would not even have to clone the repo.

## Stuff to Consider

- [ ] **Credentials**: I haven't even looked at how GCS credentials are handled by
  the tools here, but they probably need be overridable through environment variables
  for this Docker image to be useful. Tips and suggestions on this are greatly
  appreciated.

---

PS: This is my first code contrbution since I started in Spotify this week. Let me
know if there are any routines or whatever that I've missed :)