### PR TITLE
Update dependencies and fix assembly strategy, fix #11 #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Or build them yourself.
 ```
 sbt assembly
 java -jar avro-tools/target/scala-2.12/avro-tools-1.8.2.jar tojson <GCS_PATH>
-java -jar parquet-tools/target/scala-2.12/parquet-tools-1.10.1.jar cat <GCS_PATH>
-java -jar proto-tools/target/scala-2.12/proto-tools-3.4.0.jar cat <GCS_PATH>
+java -jar parquet-tools/target/scala-2.12/parquet-tools-1.11.0.jar cat <GCS_PATH>
+java -jar proto-tools/target/scala-2.12/proto-tools-3.12.2.jar cat <GCS_PATH>
 ```
 
 ## How it works:

--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,15 @@ organization := "com.spotify.data"
 name := "gcs-tools"
 version := "0.1.8-SNAPSHOT"
 
-val gcsVersion = "1.6.3-hadoop2"
-val hadoopVersion = "2.7.4"
+val gcsVersion = "hadoop2-2.1.3"
+val hadoopVersion = "2.10.0"
 val avroVersion = "1.8.2"
-val parquetVersion = "1.10.1"
-val protobufVersion = "3.4.0"
-val protobufGenericVersion = "0.2.4"
+val parquetVersion = "1.11.0"
+val protobufVersion = "3.12.2"
+val protobufGenericVersion = "0.2.8"
 
 val commonSettings = assemblySettings ++ Seq(
-  scalaVersion := "2.12.8",
+  scalaVersion := "2.12.11",
   autoScalaLibrary := false
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,7 @@ lazy val assemblySettings = Seq(
       MergeStrategy.filterDistinctLines
     case PathList("META-INF", "LICENSE")     => MergeStrategy.discard
     case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+    case PathList("META-INF", "INDEX.LIST")  => MergeStrategy.discard
     case PathList("META-INF", "DUMMY.SF")    => MergeStrategy.discard
     case PathList("META-INF", "DUMMY.RSA")   => MergeStrategy.discard
     case PathList("META-INF", "DUMMY.DSA")   => MergeStrategy.discard

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,8 @@ lazy val avroTools = project
     assemblyJarName in assembly := s"avro-tools-$avroVersion.jar",
     libraryDependencies ++= Seq(
       "org.apache.avro" % "avro-tools" % avroVersion,
+      "org.apache.hadoop" % "hadoop-common" % hadoopVersion,
+      "org.apache.hadoop" % "hadoop-client" % hadoopVersion,
       "com.google.cloud.bigdataoss" % "gcs-connector" % gcsVersion
     )
   )
@@ -69,6 +71,8 @@ lazy val protoTools = project
       "me.lyh" %% "protobuf-generic" % protobufGenericVersion exclude ("com.google.guava", "guava"),
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "org.apache.avro" % "avro-tools" % avroVersion,
+      "org.apache.hadoop" % "hadoop-common" % hadoopVersion,
+      "org.apache.hadoop" % "hadoop-client" % hadoopVersion,
       "com.google.cloud.bigdataoss" % "gcs-connector" % gcsVersion
     )
   )
@@ -76,20 +80,11 @@ lazy val protoTools = project
 
 lazy val assemblySettings = Seq(
   assemblyMergeStrategy in assembly ~= (old => {
-    // avro-tools is a fat jar which includes old Guava classes
-    case PathList("com", "google", "common", _*)  => new sbtassembly.MergeStrategy {
-      override def name = "guava"
-      override def apply(tempDir: File, path: String, files: Seq[File]): Either[String, Seq[(File, String)]] = {
-        val sources = files.map(f => f -> sbtassembly.AssemblyUtils.sourceOfFileForMerge(tempDir, f))
-        val filtered = sources.filter(_._2._1.toString.contains("/maven2/com/google/guava/guava"))
-        val pick = if (filtered.isEmpty) {
-          files.last -> path
-        } else {
-          filtered.last._1 -> path
-        }
-        Right(Seq(pick))
-      }
-    }
+    // avro-tools is a fat jar which includes old Guava & Hadoop classes
+    case PathList("com", "google", "common", _*)  =>
+      jarFilter("guava")(_.toString.contains("/com/google/guava/guava"))
+    case PathList("org", "apache", "hadoop", _*)  =>
+      jarFilter("hadoop")(_.toString.contains("/org/apache/hadoop/hadoop"))
     case s if s.endsWith(".properties")           => MergeStrategy.filterDistinctLines
     case s if s.endsWith("pom.xml")               => MergeStrategy.last
     case s if s.endsWith(".class")                => MergeStrategy.last
@@ -106,12 +101,27 @@ lazy val assemblySettings = Seq(
     case PathList("META-INF", "LICENSE")     => MergeStrategy.discard
     case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
     case PathList("META-INF", "INDEX.LIST")  => MergeStrategy.discard
-    case PathList("META-INF", "DUMMY.SF")    => MergeStrategy.discard
-    case PathList("META-INF", "DUMMY.RSA")   => MergeStrategy.discard
-    case PathList("META-INF", "DUMMY.DSA")   => MergeStrategy.discard
-    case PathList("META-INF", "MSFTSIG.RSA") => MergeStrategy.discard
-    case PathList("META-INF", "MSFTSIG.SF")  => MergeStrategy.discard
+    case PathList("META-INF", s) if s.endsWith(".DSA") => MergeStrategy.discard
+    case PathList("META-INF", s) if s.endsWith(".RSA") => MergeStrategy.discard
+    case PathList("META-INF", s) if s.endsWith(".SF")  => MergeStrategy.discard
     case PathList("META-INF", "NOTICE")      => MergeStrategy.rename
     case _                                   => MergeStrategy.last
   })
 )
+
+import sbtassembly.AssemblyUtils
+import sbtassembly.MergeStrategy
+
+def jarFilter(_name: String)(f: File => Boolean): MergeStrategy = new MergeStrategy {
+  override def name = _name
+
+  override def apply(tempDir: File, path: String, files: Seq[File]): Either[String, Seq[(File, String)]] = {
+    val filtered = files
+      .map(f => f -> AssemblyUtils.sourceOfFileForMerge(tempDir, f))
+      .filter { case (_, (jar, _, _, isJar)) =>
+        isJar && f(jar)
+      }
+    val pick = if (filtered.isEmpty) files.last else filtered.last._1
+    Right(Seq(pick -> path))
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0-RC3
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")


### PR DESCRIPTION
`avro-tools-1.8.2.jar` is a fat jar with very old Guava and Hadoop classes. After updating to the latest `gcs-connector`, we need to remove those using a custom `MergeStrategy`.

Also updated discard strategies of `META-INF/*.{DSA,RSA,SF}` since some Google jars are now signed.