### PR TITLE
pin jackson-databind version to 2.11.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,8 @@ lazy val protoTools = project
       "org.apache.hadoop" % "hadoop-common" % hadoopVersion,
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion,
       "com.google.cloud.bigdataoss" % "gcs-connector" % gcsVersion
-    )
+    ),
+    dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.2"
   )
   .dependsOn(shared)
 


### PR DESCRIPTION
there's an incompatibility within scala module and jackson-databind causing a runtime error

on a fresh install of `gcs-proto-tools`,

```bash
$ proto-tools tojson file.protobuf.avro

Exception in thread "main" java.lang.ExceptionInInitializerError
	at me.lyh.protobuf.generic.Schema$.fromJson(Schema.scala:43)
	at org.apache.avro.tool.ProtobufReader.<init>(ProtobufReader.scala:8)
	at org.apache.avro.tool.ProtoToJsonTool.run(ProtoToJsonTool.java:61)
	at org.apache.avro.tool.ProtoMain.run(ProtoMain.java:64)
	at org.apache.avro.tool.ProtoMain.main(ProtoMain.java:53)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.11.2 requires Jackson Databind version >= 2.11.0 and < 2.12.0
	at com.fasterxml.jackson.module.scala.JacksonModule.setupModule(JacksonModule.scala:61)
	at com.fasterxml.jackson.module.scala.JacksonModule.setupModule$(JacksonModule.scala:46)
	at com.fasterxml.jackson.module.scala.DefaultScalaModule.setupModule(DefaultScalaModule.scala:17)
	at com.fasterxml.jackson.databind.ObjectMapper.registerModule(ObjectMapper.java:835)
	at me.lyh.protobuf.generic.SchemaMapper$.<clinit>(Schema.scala:127)
	... 5 more
```

when making the proposed change to `build.sbt` locally, i was able to run the following successfully:

```bash
$ sbt clean assembly
$ java -jar proto-tools/target/scala-2.13/proto-tools-3.22.2.jar tojson file.protobuf.avro
```