### PR TITLE
Fix parquet-cli packaging

### DIFF
--- a/avro-tools/src/test/scala/org/apache/avro/tool/MainSpec.scala
+++ b/avro-tools/src/test/scala/org/apache/avro/tool/MainSpec.scala
@@ -1,0 +1,16 @@
+package org.apache.avro.tool
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MainSpec extends AnyFlatSpec with Matchers {
+
+  "avro-tools" should "display help" in {
+    noException shouldBe thrownBy {
+      // main calls System.exit. test with run
+      val run = classOf[Main].getDeclaredMethod("run", classOf[Array[String]])
+      run.setAccessible(true)
+      run.invoke(new Main(), Array("--help"))
+    }
+  }
+}

--- a/parquet-cli/src/test/scala/org/apache/parquet/cli/MainSpec.scala
+++ b/parquet-cli/src/test/scala/org/apache/parquet/cli/MainSpec.scala
@@ -1,0 +1,19 @@
+package org.apache.parquet.cli
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.util.ToolRunner
+import org.apache.log4j.PropertyConfigurator
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.LoggerFactory
+
+class MainSpec extends AnyFlatSpec with Matchers {
+
+  "parquet-cli" should "display help" in {
+    noException shouldBe thrownBy {
+      PropertyConfigurator.configure(classOf[Main].getResource("/cli-logging.properties"));
+      val console = LoggerFactory.getLogger(classOf[Main])
+      ToolRunner.run(new Configuration, new Main(console), Array("--help"))
+    }
+  }
+}


### PR DESCRIPTION
Revert to `parquet-cli:1.13.1`.
Add test to make sure main is able to run.

See https://github.com/apache/parquet-java/issues/3016